### PR TITLE
Change Content Type to application/x-www-form-urlencoded in sending APIPost Call

### DIFF
--- a/EMSMobileSDK/EMSAPI.swift
+++ b/EMSMobileSDK/EMSAPI.swift
@@ -135,11 +135,17 @@ public class EMSAPI: NSObject {
         }
         
         var urlRequest = URLRequest(url: requestURL)
+        urlRequest.setValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
         urlRequest.httpMethod = "POST"
         
         if let data = data {
-            urlRequest.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
-            urlRequest.httpBody = try? JSONSerialization.data(withJSONObject: data, options: [])
+            var body = ""
+
+            for (key, value) in data {
+                body = body.isEmpty ? "\(key)=\(value)" : "\(body)&\(key)=\(value)"
+            }
+
+            urlRequest.httpBody = Data(body.utf8)
         }
         
         let dataTask = session.dataTask(with: urlRequest) { (_, urlResponse, _) in


### PR DESCRIPTION
Hi @jvitug-sl 

The marketing suite console expects the content type to be application/x-www-form-urlencoded.

The other requests are unaffected since they can handle Content-Type application/json just fine. I confirmed this by running the unit tests and they are returning expected json values too.

For your approval.

FYI @raybalingit 

Thanks,
JJ